### PR TITLE
feat: make `case` property optional in naming-rules

### DIFF
--- a/lib/rules/naming-rules.ts
+++ b/lib/rules/naming-rules.ts
@@ -46,6 +46,14 @@ const meta: Rule.RuleModule['meta'] = {
               },
             },
             required: ['target'],
+            anyOf: [
+              {
+                required: ['case'],
+              },
+              {
+                required: ['patterns'],
+              },
+            ],
           },
         },
       },

--- a/lib/rules/naming-rules.ts
+++ b/lib/rules/naming-rules.ts
@@ -45,6 +45,7 @@ const meta: Rule.RuleModule['meta'] = {
                 },
               },
             },
+            required: ['target'],
           },
         },
       },
@@ -56,10 +57,10 @@ type RuleOptions = {
   index: boolean;
   rules: [
     {
-      case: keyof typeof regexCaseMap;
+      case?: keyof typeof regexCaseMap;
       target: string;
-      patterns: string;
-      excludes: string[];
+      patterns?: string;
+      excludes?: string[];
     },
   ];
 };

--- a/lib/rules/naming-rules.ts
+++ b/lib/rules/naming-rules.ts
@@ -93,23 +93,25 @@ export const namingRules: Rule.RuleModule = {
             return;
           }
 
-          if (
-            !micromatch.isMatch(
-              // Consider cases with leading underscores. (ex: _document.tsx)
-              filename.replace(/^_/, ''),
-              regexCaseMap[targetRule.case],
-            )
-          ) {
-            context.report({
-              node,
-              messageId: 'errorNoMatchCase',
-              data: {
-                file,
-                caseType: targetRule.case,
-              },
-            });
+          if (targetRule.case) {
+            if (
+              !micromatch.isMatch(
+                // Consider cases with leading underscores. (ex: _document.tsx)
+                filename.replace(/^_/, ''),
+                regexCaseMap[targetRule.case],
+              )
+            ) {
+              context.report({
+                node,
+                messageId: 'errorNoMatchCase',
+                data: {
+                  file,
+                  caseType: targetRule.case,
+                },
+              });
 
-            return;
+              return;
+            }
           }
 
           if (targetRule.patterns) {

--- a/test/rules/naming-rules.test.ts
+++ b/test/rules/naming-rules.test.ts
@@ -86,6 +86,21 @@ ruleTester.run('naming-rules', namingRules, {
           ],
         },
       ],
+    },    
+    {
+      code: '',
+      filename: '/components/Button/__tests__/Button.test.tsx',
+      options: [
+        {
+          rules: [
+            {
+              target: '**',
+              patterns: '^(?!.*\\.test\\.(ts|tsx)$).*$',
+              excludes: ['__tests__'],
+            },
+          ],
+        },
+      ],
     },
   ],
   invalid: [
@@ -121,6 +136,22 @@ ruleTester.run('naming-rules', namingRules, {
         },
       ],
       errors: ['hooks.tsx does not match filename pattern.'],
+    },
+    {
+      code: '',
+      filename: '/components/Button/Button.test.tsx',
+      options: [
+        {
+          rules: [
+            {
+              target: '**',
+              patterns: '^(?!.*\\.test\\.(ts|tsx)$).*$',
+              excludes: ['__tests__'],
+            },
+          ],
+        },
+      ],
+      errors: ['Button.test.tsx does not match filename pattern.'],
     },
   ],
 });


### PR DESCRIPTION
## Related Issue
Closes #15

## Description
Makes `case` property optional for flexible rule definition.

## Changes
- **Optional `case`**: Skip case validation when `case` is not specified
- **Schema clarity**: Explicitly define required properties

## Test Case
Added test case for managing test files exclusively under `__tests__` directories. This demonstrates how to enforce file structure rules without requiring case validation.
- **OK**: `/components/Button/__tests__/Button.test.tsx` (excluded by `__tests__`)
- **NG**: `/components/Button/Button.test.tsx` (caught by pattern validation)

## Breaking Changes
None - backward compatible enhancement.